### PR TITLE
Run CI on solidity contracts using GitHub Actions

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -1,0 +1,32 @@
+---
+name: contracts
+on:
+  push:
+jobs:
+  tests:
+    defaults:
+      run:
+        working-directory: ./packages/contracts
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install pnpm and install dependencies 
+        uses: pnpm/action-setup@v2.1.0
+        with:
+          version: 6.0.2
+          run_install: true
+      - name: Run tests
+        run: pnpm run test
+        env:
+          # FIXME hardhat currently pre-configured with many more vars than this
+          # it won't load at all unless they are all defined
+          RPC_ENDPOINT: ${{ secrets.RPC_ENDPOINT }}
+          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}


### PR DESCRIPTION
greetings noble repository maintainer

This is my GitHub Actions CI runner for smart contracts. There are many like it, but this one works with pnpm

This runner is just for testing smart contracts; I have some cypress test runners for the web app if interesting

One major issue 2 discuss:

`hardhat.config.ts` is pre-configured with multiple networks out-of-the-box, and the `.env.sample` is empty. hardhat won't load at all unless these are all set, despite the fact that `pnpm run test` does not require any configuration at all

I'd potentailly suggest smartening up `hardhat.config.ts` to check for presence of per-network vars, and use those? Or ship with those commented out, so tests can run out-of-the-box.
