### PR TITLE
Enforce pnpm-only across all 3 packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "node": ">=14 <16"
   },
   "scripts": {
+    "preinstall": "yes | npx only-allow pnpm",
     "dev": "pnpm -r dev --stream"
   },
   "devDependencies": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -5,7 +5,6 @@
     "node": ">=14 <16"
   },
   "scripts": {
-    "preinstall": "only-allow pnpm",
     "dev": "next dev & graphql-codegen --watch",
     "build": "next build",
     "start": "next start",
@@ -37,7 +36,6 @@
     "@types/node": "17.0.0",
     "@types/react": "17.0.37",
     "autoprefixer": "^10.4.0",
-    "only-allow": "^1.1.0",
     "postcss": "^8.4.5",
     "tailwindcss": "^3.0.5",
     "typescript": "4.5.5"

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -5,6 +5,7 @@
     "node": ">=14 <16"
   },
   "scripts": {
+    "preinstall": "yes | npx only-allow pnpm",
     "dev": "next dev & graphql-codegen --watch",
     "build": "next build",
     "start": "next start",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -5,6 +5,7 @@
     "node": ">=14 <16"
   },
   "scripts": {
+    "preinstall": "only-allow pnpm",
     "dev": "next dev & graphql-codegen --watch",
     "build": "next build",
     "start": "next start",
@@ -36,6 +37,7 @@
     "@types/node": "17.0.0",
     "@types/react": "17.0.37",
     "autoprefixer": "^10.4.0",
+    "only-allow": "^1.1.0",
     "postcss": "^8.4.5",
     "tailwindcss": "^3.0.5",
     "typescript": "4.5.5"

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -5,6 +5,7 @@
     "node": ">=14 <16"
   },
   "scripts": {
+    "preinstall": "only-allow pnpm",
     "prepare": "npm run build",
     "start": "hardhat node",
     "test": "hardhat test",
@@ -37,6 +38,7 @@
     "ethers": "^5.5.2",
     "hardhat": "^2.7.1",
     "hardhat-gas-reporter": "^1.0.6",
+    "only-allow": "^1.1.0",
     "ts-node": "^10.4.0",
     "typechain": "^6.0.5",
     "typescript": "^4.5.5"

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -5,7 +5,6 @@
     "node": ">=14 <16"
   },
   "scripts": {
-    "preinstall": "only-allow pnpm",
     "prepare": "npm run build",
     "start": "hardhat node",
     "test": "hardhat test",
@@ -38,7 +37,6 @@
     "ethers": "^5.5.2",
     "hardhat": "^2.7.1",
     "hardhat-gas-reporter": "^1.0.6",
-    "only-allow": "^1.1.0",
     "ts-node": "^10.4.0",
     "typechain": "^6.0.5",
     "typescript": "^4.5.5"

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -5,6 +5,7 @@
     "node": ">=14 <16"
   },
   "scripts": {
+    "preinstall": "yes | npx only-allow pnpm",
     "prepare": "npm run build",
     "start": "hardhat node",
     "test": "hardhat test",

--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -5,6 +5,7 @@
     "node": ">=14 <16"
   },
   "scripts": {
+    "preinstall": "yes | npx only-allow pnpm",
     "codegen": "graph codegen subgraph*.yaml",
     "build": "graph build subgraph*.yaml",
     "deploy:matic": "graph deploy --node https://api.thegraph.com/deploy/ holic/example-nft subgraph-matic.yaml",

--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -1,11 +1,10 @@
 {
   "name": "@web3-dapp-scaffold/subgraph",
-  "private": true,
+  "private":true,
   "engines": {
     "node": ">=14 <16"
   },
   "scripts": {
-    "preinstall": "only-allow pnpm",
     "codegen": "graph codegen subgraph*.yaml",
     "build": "graph build subgraph*.yaml",
     "deploy:matic": "graph deploy --node https://api.thegraph.com/deploy/ holic/example-nft subgraph-matic.yaml",
@@ -14,8 +13,5 @@
   "dependencies": {
     "@graphprotocol/graph-cli": "0.25.1",
     "@graphprotocol/graph-ts": "0.24.1"
-  },
-  "devDependencies": {
-    "only-allow": "^1.1.0"
   }
 }

--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@web3-dapp-scaffold/subgraph",
-  "private":true,
+  "private": true,
   "engines": {
     "node": ">=14 <16"
   },
   "scripts": {
+    "preinstall": "only-allow pnpm",
     "codegen": "graph codegen subgraph*.yaml",
     "build": "graph build subgraph*.yaml",
     "deploy:matic": "graph deploy --node https://api.thegraph.com/deploy/ holic/example-nft subgraph-matic.yaml",
@@ -13,5 +14,8 @@
   "dependencies": {
     "@graphprotocol/graph-cli": "0.25.1",
     "@graphprotocol/graph-ts": "0.24.1"
+  },
+  "devDependencies": {
+    "only-allow": "^1.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,7 @@ importers:
       debug: ^4.3.3
       graphql: ^16.2.0
       next: 12.1.0
+      only-allow: ^1.1.0
       postcss: ^8.4.5
       react: 17.0.2
       react-dom: 17.0.2
@@ -76,6 +77,7 @@ importers:
       '@types/node': 17.0.0
       '@types/react': 17.0.37
       autoprefixer: 10.4.2_postcss@8.4.5
+      only-allow: 1.1.0
       postcss: 8.4.5
       tailwindcss: 3.0.15_ef48b3b8837f8a23677bffe8f9cd866d
       typescript: 4.5.5
@@ -100,6 +102,7 @@ importers:
       ethers: ^5.5.2
       hardhat: ^2.7.1
       hardhat-gas-reporter: ^1.0.6
+      only-allow: ^1.1.0
       ts-node: ^10.4.0
       typechain: ^6.0.5
       typescript: ^4.5.5
@@ -123,6 +126,7 @@ importers:
       ethers: 5.5.3
       hardhat: 2.8.3
       hardhat-gas-reporter: 1.0.7_hardhat@2.8.3
+      only-allow: 1.1.0
       ts-node: 10.4.0_06de4b00c69b73d094e2c5b522a6ad57
       typechain: 6.1.0_typescript@4.5.5
       typescript: 4.5.5
@@ -131,9 +135,12 @@ importers:
     specifiers:
       '@graphprotocol/graph-cli': 0.25.1
       '@graphprotocol/graph-ts': 0.24.1
+      only-allow: ^1.1.0
     dependencies:
       '@graphprotocol/graph-cli': 0.25.1
       '@graphprotocol/graph-ts': 0.24.1
+    devDependencies:
+      only-allow: 1.1.0
 
 packages:
 
@@ -2382,6 +2389,12 @@ packages:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  /ansi-align/3.0.1:
+    resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
+    dependencies:
+      string-width: 4.2.3
+    dev: true
+
   /ansi-colors/3.2.3:
     resolution: {integrity: sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==}
     engines: {node: '>=6'}
@@ -2781,6 +2794,20 @@ packages:
       readable-stream: 3.6.0
     dev: false
 
+  /boxen/4.2.0:
+    resolution: {integrity: sha512-eB4uT9RGzg2odpER62bBwSLvUeGC+WbRjjyyFhGsKnc8wp/m0+hQsMUvUe3H2V0D5vw0nBdO1hCJoZo5mKeuIQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      ansi-align: 3.0.1
+      camelcase: 5.3.1
+      chalk: 3.0.0
+      cli-boxes: 2.2.1
+      string-width: 4.2.3
+      term-size: 2.2.1
+      type-fest: 0.8.1
+      widest-line: 3.1.0
+    dev: true
+
   /brace-expansion/1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
     dependencies:
@@ -2996,7 +3023,6 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
-    dev: false
 
   /chalk/4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -3129,6 +3155,11 @@ packages:
   /classnames/2.3.1:
     resolution: {integrity: sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==}
     dev: false
+
+  /cli-boxes/2.2.1:
+    resolution: {integrity: sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==}
+    engines: {node: '>=6'}
+    dev: true
 
   /cli-cursor/2.1.0:
     resolution: {integrity: sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=}
@@ -6856,6 +6887,14 @@ packages:
     dependencies:
       mimic-fn: 2.1.0
 
+  /only-allow/1.1.0:
+    resolution: {integrity: sha512-HYiuMpRuy0d0DjoQZwhwO1Ueal0NXJ2I4mNxLv3aGw/1naRcAAzVC953WNpcbjlo+ak3WsoKDjHvoMd2cSZLpw==}
+    hasBin: true
+    dependencies:
+      boxen: 4.2.0
+      which-pm-runs: 1.1.0
+    dev: true
+
   /optimist/0.3.7:
     resolution: {integrity: sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=}
     dependencies:
@@ -8327,6 +8366,11 @@ packages:
       yallist: 4.0.0
     dev: false
 
+  /term-size/2.2.1:
+    resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
+    engines: {node: '>=8'}
+    dev: true
+
   /text-table/0.2.0:
     resolution: {integrity: sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=}
     dev: true
@@ -8559,6 +8603,11 @@ packages:
 
   /type-fest/0.7.1:
     resolution: {integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /type-fest/0.8.1:
+    resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
     engines: {node: '>=8'}
     dev: true
 
@@ -8801,6 +8850,11 @@ packages:
     resolution: {integrity: sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=}
     dev: true
 
+  /which-pm-runs/1.1.0:
+    resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
+    engines: {node: '>=4'}
+    dev: true
+
   /which/1.3.1:
     resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
     hasBin: true
@@ -8819,6 +8873,13 @@ packages:
     resolution: {integrity: sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==}
     dependencies:
       string-width: 2.1.1
+    dev: true
+
+  /widest-line/3.1.0:
+    resolution: {integrity: sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==}
+    engines: {node: '>=8'}
+    dependencies:
+      string-width: 4.2.3
     dev: true
 
   /wonka/4.0.15:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,7 +44,6 @@ importers:
       debug: ^4.3.3
       graphql: ^16.2.0
       next: 12.1.0
-      only-allow: ^1.1.0
       postcss: ^8.4.5
       react: 17.0.2
       react-dom: 17.0.2
@@ -77,7 +76,6 @@ importers:
       '@types/node': 17.0.0
       '@types/react': 17.0.37
       autoprefixer: 10.4.2_postcss@8.4.5
-      only-allow: 1.1.0
       postcss: 8.4.5
       tailwindcss: 3.0.15_ef48b3b8837f8a23677bffe8f9cd866d
       typescript: 4.5.5
@@ -102,7 +100,6 @@ importers:
       ethers: ^5.5.2
       hardhat: ^2.7.1
       hardhat-gas-reporter: ^1.0.6
-      only-allow: ^1.1.0
       ts-node: ^10.4.0
       typechain: ^6.0.5
       typescript: ^4.5.5
@@ -126,7 +123,6 @@ importers:
       ethers: 5.5.3
       hardhat: 2.8.3
       hardhat-gas-reporter: 1.0.7_hardhat@2.8.3
-      only-allow: 1.1.0
       ts-node: 10.4.0_06de4b00c69b73d094e2c5b522a6ad57
       typechain: 6.1.0_typescript@4.5.5
       typescript: 4.5.5
@@ -135,12 +131,9 @@ importers:
     specifiers:
       '@graphprotocol/graph-cli': 0.25.1
       '@graphprotocol/graph-ts': 0.24.1
-      only-allow: ^1.1.0
     dependencies:
       '@graphprotocol/graph-cli': 0.25.1
       '@graphprotocol/graph-ts': 0.24.1
-    devDependencies:
-      only-allow: 1.1.0
 
 packages:
 
@@ -2389,12 +2382,6 @@ packages:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  /ansi-align/3.0.1:
-    resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
-    dependencies:
-      string-width: 4.2.3
-    dev: true
-
   /ansi-colors/3.2.3:
     resolution: {integrity: sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==}
     engines: {node: '>=6'}
@@ -2794,20 +2781,6 @@ packages:
       readable-stream: 3.6.0
     dev: false
 
-  /boxen/4.2.0:
-    resolution: {integrity: sha512-eB4uT9RGzg2odpER62bBwSLvUeGC+WbRjjyyFhGsKnc8wp/m0+hQsMUvUe3H2V0D5vw0nBdO1hCJoZo5mKeuIQ==}
-    engines: {node: '>=8'}
-    dependencies:
-      ansi-align: 3.0.1
-      camelcase: 5.3.1
-      chalk: 3.0.0
-      cli-boxes: 2.2.1
-      string-width: 4.2.3
-      term-size: 2.2.1
-      type-fest: 0.8.1
-      widest-line: 3.1.0
-    dev: true
-
   /brace-expansion/1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
     dependencies:
@@ -3023,6 +2996,7 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+    dev: false
 
   /chalk/4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -3155,11 +3129,6 @@ packages:
   /classnames/2.3.1:
     resolution: {integrity: sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==}
     dev: false
-
-  /cli-boxes/2.2.1:
-    resolution: {integrity: sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==}
-    engines: {node: '>=6'}
-    dev: true
 
   /cli-cursor/2.1.0:
     resolution: {integrity: sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=}
@@ -6887,14 +6856,6 @@ packages:
     dependencies:
       mimic-fn: 2.1.0
 
-  /only-allow/1.1.0:
-    resolution: {integrity: sha512-HYiuMpRuy0d0DjoQZwhwO1Ueal0NXJ2I4mNxLv3aGw/1naRcAAzVC953WNpcbjlo+ak3WsoKDjHvoMd2cSZLpw==}
-    hasBin: true
-    dependencies:
-      boxen: 4.2.0
-      which-pm-runs: 1.1.0
-    dev: true
-
   /optimist/0.3.7:
     resolution: {integrity: sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=}
     dependencies:
@@ -8366,11 +8327,6 @@ packages:
       yallist: 4.0.0
     dev: false
 
-  /term-size/2.2.1:
-    resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
-    engines: {node: '>=8'}
-    dev: true
-
   /text-table/0.2.0:
     resolution: {integrity: sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=}
     dev: true
@@ -8603,11 +8559,6 @@ packages:
 
   /type-fest/0.7.1:
     resolution: {integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /type-fest/0.8.1:
-    resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
     engines: {node: '>=8'}
     dev: true
 
@@ -8850,11 +8801,6 @@ packages:
     resolution: {integrity: sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=}
     dev: true
 
-  /which-pm-runs/1.1.0:
-    resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
-    engines: {node: '>=4'}
-    dev: true
-
   /which/1.3.1:
     resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
     hasBin: true
@@ -8873,13 +8819,6 @@ packages:
     resolution: {integrity: sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==}
     dependencies:
       string-width: 2.1.1
-    dev: true
-
-  /widest-line/3.1.0:
-    resolution: {integrity: sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==}
-    engines: {node: '>=8'}
-    dependencies:
-      string-width: 4.2.3
     dev: true
 
   /wonka/4.0.15:


### PR DESCRIPTION
Using `only-allow`

Is this the right pnpm workspace pattern -- installing it in each app? Otherwise need to use "npx only-allow" or pnpm equivalent, which then prompts to install it anyway. Seems simpler to just include as an explicit dependency
