### PR TITLE
Lock everything to node 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "web3-dapp-scaffold",
   "private": true,
+  "engines": {
+    "node": ">=14 <16"
+  },
   "scripts": {
     "dev": "pnpm -r dev --stream"
   },

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@web3-dapp-scaffold/app",
   "private": true,
+  "engines": {
+    "node": ">=14 <16"
+  },
   "scripts": {
     "dev": "next dev & graphql-codegen --watch",
     "build": "next build",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@web3-dapp-scaffold/contracts",
   "private": true,
+  "engines": {
+    "node": ">=14 <16"
+  },
   "scripts": {
     "prepare": "npm run build",
     "start": "hardhat node",

--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@web3-dapp-scaffold/subgraph",
   "private":true,
+  "engines": {
+    "node": ">=14 <16"
+  },
   "scripts": {
     "codegen": "graph codegen subgraph*.yaml",
     "build": "graph build subgraph*.yaml",


### PR DESCRIPTION
Locked it in all three packages and at top-level O_o

Would it be possible to only lock at the top-level? That didn't behave well with my version mgr of choice, `nodenv`
