### PR TITLE
feat: test moving foundry config for vs code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,10 @@
     {
       "mode": "auto"
     }
-  ]
+  ],
+  "solidity.packageDefaultDependenciesContractsDirectory": "packages/contracts/src",
+  "solidity.packageDefaultDependenciesDirectory": "packages/contracts/lib",
+  "search.exclude": {
+    "packages/contracts/lib": true
+  }
 }

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,8 +1,9 @@
 [default]
-src = 'src'
-test = 'test'
-out = 'out'
-libs = ['lib']
+src = 'packages/contracts/src'
+test = 'packages/contracts/test'
+out = 'packages/contracts/out'
+cache_path = 'packages/contracts/cache'
+libs = ['packages/contracts/lib']
 verbosity = 2
 # Foundry is fast enough that we can ignore the cache for now
 force = false

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,3 +1,9 @@
+# Ideally this file would live inside packages/contracts, but VSCode doesn't
+# know how to resolve Solidity imports for the workspace without opening the
+# contracts directory separately.
+#
+# See https://github.com/holic/web3-scaffold/pull/23
+
 [default]
 src = 'packages/contracts/src'
 test = 'packages/contracts/test'
@@ -5,8 +11,6 @@ out = 'packages/contracts/out'
 cache_path = 'packages/contracts/cache'
 libs = ['packages/contracts/lib']
 verbosity = 2
-# Foundry is fast enough that we can ignore the cache for now
-force = false
 bytecode_hash = 'none'
 solc_version = '0.8.13'
 extra_output_files = ['abi']

--- a/packages/contracts/remappings.txt
+++ b/packages/contracts/remappings.txt
@@ -1,3 +1,0 @@
-forge-std/=lib/forge-std/src/
-@openzeppelin/=lib/openzeppelin-contracts/
-erc721a/=lib/ERC721A/

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,0 +1,3 @@
+forge-std/=packages/contracts/lib/forge-std/src/
+@openzeppelin/=packages/contracts/lib/openzeppelin-contracts/
+erc721a/=packages/contracts/lib/ERC721A/


### PR DESCRIPTION
Currently VSCode can't resolve imports when forge project is inside a monorepo. This PR exists to demonstrate the workaround that forkers of web3-scaffold may want to try while https://github.com/juanfranblanco/vscode-solidity/issues/335 is pending. (See also discussion in https://github.com/foundry-rs/foundry/issues/1438)