### PR TITLE
fix: cleanup ssr markup mismatch errors

### DIFF
--- a/packages/app/src/Inventory.tsx
+++ b/packages/app/src/Inventory.tsx
@@ -26,13 +26,19 @@ export const Inventory = () => {
     },
   });
 
+  // Temporarily workaround hydration issues where server-rendered markup
+  // doesn't match the client due to localStorage caching in wagmi
+  // See https://github.com/holic/web3-scaffold/pull/26
   const isMounted = useIsMounted();
+  if (!isMounted) {
+    return null;
+  }
 
   if (!address) {
     return null;
   }
 
-  if (!isMounted || !query.data) {
+  if (!query.data) {
     return <PendingIcon />;
   }
 

--- a/packages/app/src/Inventory.tsx
+++ b/packages/app/src/Inventory.tsx
@@ -28,11 +28,11 @@ export const Inventory = () => {
 
   const isMounted = useIsMounted();
 
-  if (!address || !isMounted) {
+  if (!address) {
     return null;
   }
 
-  if (!query.data) {
+  if (!isMounted || !query.data) {
     return <PendingIcon />;
   }
 

--- a/packages/app/src/Inventory.tsx
+++ b/packages/app/src/Inventory.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { gql } from "urql";
 import { useAccount, useNetwork } from "wagmi";
 
@@ -25,7 +26,12 @@ export const Inventory = () => {
     },
   });
 
-  if (!address) {
+  const [hasLoaded, setHasLoaded] = useState(false);
+  useEffect(() => {
+    setHasLoaded(true);
+  }, []);
+
+  if (!address || !hasLoaded) {
     return null;
   }
 

--- a/packages/app/src/Inventory.tsx
+++ b/packages/app/src/Inventory.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useState } from "react";
 import { gql } from "urql";
 import { useAccount, useNetwork } from "wagmi";
 
 import { useInventoryQuery } from "./codegen/subgraph";
 import { exampleNFTContract } from "./contracts";
 import { PendingIcon } from "./PendingIcon";
+import { useIsMounted } from "./useIsMounted";
 
 gql`
   query Inventory($owner: Bytes!) {
@@ -26,12 +26,9 @@ export const Inventory = () => {
     },
   });
 
-  const [hasLoaded, setHasLoaded] = useState(false);
-  useEffect(() => {
-    setHasLoaded(true);
-  }, []);
+  const isMounted = useIsMounted();
 
-  if (!address || !hasLoaded) {
+  if (!address || !isMounted) {
     return null;
   }
 

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -22,12 +22,12 @@ const HomePage: NextPage = () => {
       <div className="flex-grow flex flex-col gap-4 items-center justify-center p-8 pb-[50vh]">
         <h1 className="text-4xl">Example NFT</h1>
 
-        {isMounted && (
+        {isMounted ? (
           <p>
             {totalSupply.data?.toNumber().toLocaleString() ?? "??"}/
             {maxSupply.data?.toNumber().toLocaleString() ?? "??"} minted
           </p>
-        )}
+        ) : null}
 
         <MintButton />
         <Inventory />

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -22,12 +22,17 @@ const HomePage: NextPage = () => {
       <div className="flex-grow flex flex-col gap-4 items-center justify-center p-8 pb-[50vh]">
         <h1 className="text-4xl">Example NFT</h1>
 
-        {isMounted ? (
-          <p>
-            {totalSupply.data?.toNumber().toLocaleString() ?? "??"}/
-            {maxSupply.data?.toNumber().toLocaleString() ?? "??"} minted
-          </p>
-        ) : null}
+        {/* Use isMounted to temporarily workaround hydration issues where
+        server-rendered markup doesn't match the client due to localStorage
+        caching in wagmi. See https://github.com/holic/web3-scaffold/pull/26 */}
+        <p>
+          {(isMounted ? totalSupply.data?.toNumber().toLocaleString() : null) ??
+            "??"}
+          /
+          {(isMounted ? maxSupply.data?.toNumber().toLocaleString() : null) ??
+            "??"}{" "}
+          minted
+        </p>
 
         <MintButton />
         <Inventory />

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -1,10 +1,10 @@
 import { ConnectButton } from "@rainbow-me/rainbowkit";
 import type { NextPage } from "next";
-import { useEffect, useState } from "react";
 
 import { useExampleNFTContractRead } from "../contracts";
 import { Inventory } from "../Inventory";
 import { MintButton } from "../MintButton";
+import { useIsMounted } from "../useIsMounted";
 
 const HomePage: NextPage = () => {
   const totalSupply = useExampleNFTContractRead("totalSupply", {
@@ -12,10 +12,7 @@ const HomePage: NextPage = () => {
   });
   const maxSupply = useExampleNFTContractRead("MAX_SUPPLY");
 
-  const [hasLoaded, setHasLoaded] = useState(false);
-  useEffect(() => {
-    setHasLoaded(true);
-  }, []);
+  const isMounted = useIsMounted();
 
   return (
     <div className="min-h-screen flex flex-col">
@@ -25,7 +22,7 @@ const HomePage: NextPage = () => {
       <div className="flex-grow flex flex-col gap-4 items-center justify-center p-8 pb-[50vh]">
         <h1 className="text-4xl">Example NFT</h1>
 
-        {hasLoaded && (
+        {isMounted && (
           <p>
             {totalSupply.data?.toNumber().toLocaleString() ?? "??"}/
             {maxSupply.data?.toNumber().toLocaleString() ?? "??"} minted

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -1,5 +1,6 @@
 import { ConnectButton } from "@rainbow-me/rainbowkit";
 import type { NextPage } from "next";
+import { useEffect, useState } from "react";
 
 import { useExampleNFTContractRead } from "../contracts";
 import { Inventory } from "../Inventory";
@@ -11,6 +12,11 @@ const HomePage: NextPage = () => {
   });
   const maxSupply = useExampleNFTContractRead("MAX_SUPPLY");
 
+  const [hasLoaded, setHasLoaded] = useState(false);
+  useEffect(() => {
+    setHasLoaded(true);
+  }, []);
+
   return (
     <div className="min-h-screen flex flex-col">
       <div className="self-end p-2">
@@ -19,10 +25,12 @@ const HomePage: NextPage = () => {
       <div className="flex-grow flex flex-col gap-4 items-center justify-center p-8 pb-[50vh]">
         <h1 className="text-4xl">Example NFT</h1>
 
-        <p>
-          {totalSupply.data?.toNumber().toLocaleString() ?? "??"}/
-          {maxSupply.data?.toNumber().toLocaleString() ?? "??"} minted
-        </p>
+        {hasLoaded && (
+          <p>
+            {totalSupply.data?.toNumber().toLocaleString() ?? "??"}/
+            {maxSupply.data?.toNumber().toLocaleString() ?? "??"} minted
+          </p>
+        )}
 
         <MintButton />
         <Inventory />

--- a/packages/app/src/useIsMounted.tsx
+++ b/packages/app/src/useIsMounted.tsx
@@ -1,0 +1,9 @@
+import { useEffect, useState } from "react";
+
+export function useIsMounted() {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  return mounted;
+}


### PR DESCRIPTION
Currently some markup depends on client-side requests (or local storage caches). This can cause mismatch errors with Next.js server-side rendering. One way we can minimize these errors is wrapping into an `isLoaded` conditional with `useEffect`.

Example error:

```
next-dev.js?d62b:32 Warning: Text content did not match. Server: "??" Client: "3"
    at p
    at div
    at div
    at HomePage (webpack-internal:///./src/pages/index.tsx:18:92)
```