### PR TITLE
fix: cleanup lint warnings

### DIFF
--- a/packages/app/.eslintignore
+++ b/packages/app/.eslintignore
@@ -1,0 +1,1 @@
+codegen

--- a/packages/app/codegen/subgraph.ts
+++ b/packages/app/codegen/subgraph.ts
@@ -1,17 +1,11 @@
-import { gql } from "urql";
-import * as Urql from "urql";
+import { gql } from 'urql';
+import * as Urql from 'urql';
 
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
-export type Exact<T extends { [key: string]: unknown }> = {
-  [K in keyof T]: T[K];
-};
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]?: Maybe<T[SubKey]>;
-};
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]: Maybe<T[SubKey]>;
-};
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
@@ -20,149 +14,152 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   BigDecimal: any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   BigInt: any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Bytes: any;
 };
 
 export type BlockChangedFilter = {
-  readonly number_gte: Scalars["Int"];
+  readonly number_gte: Scalars['Int'];
 };
 
 export type Block_Height = {
-  readonly hash?: InputMaybe<Scalars["Bytes"]>;
-  readonly number?: InputMaybe<Scalars["Int"]>;
-  readonly number_gte?: InputMaybe<Scalars["Int"]>;
+  readonly hash?: InputMaybe<Scalars['Bytes']>;
+  readonly number?: InputMaybe<Scalars['Int']>;
+  readonly number_gte?: InputMaybe<Scalars['Int']>;
 };
 
 /** Defines the order direction, either ascending or descending */
 export enum OrderDirection {
-  Asc = "asc",
-  Desc = "desc",
+  Asc = 'asc',
+  Desc = 'desc'
 }
 
 export type Query = {
-  readonly __typename?: "Query";
+  readonly __typename?: 'Query';
   /** Access to subgraph metadata */
   readonly _meta?: Maybe<_Meta_>;
   readonly token?: Maybe<Token>;
   readonly tokens: ReadonlyArray<Token>;
 };
+
 
 export type Query_MetaArgs = {
   block?: InputMaybe<Block_Height>;
 };
 
+
 export type QueryTokenArgs = {
   block?: InputMaybe<Block_Height>;
-  id: Scalars["ID"];
+  id: Scalars['ID'];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
+
 export type QueryTokensArgs = {
   block?: InputMaybe<Block_Height>;
-  first?: InputMaybe<Scalars["Int"]>;
+  first?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Token_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]>;
+  skip?: InputMaybe<Scalars['Int']>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<Token_Filter>;
 };
 
 export type Subscription = {
-  readonly __typename?: "Subscription";
+  readonly __typename?: 'Subscription';
   /** Access to subgraph metadata */
   readonly _meta?: Maybe<_Meta_>;
   readonly token?: Maybe<Token>;
   readonly tokens: ReadonlyArray<Token>;
 };
 
+
 export type Subscription_MetaArgs = {
   block?: InputMaybe<Block_Height>;
 };
 
+
 export type SubscriptionTokenArgs = {
   block?: InputMaybe<Block_Height>;
-  id: Scalars["ID"];
+  id: Scalars['ID'];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
+
 export type SubscriptionTokensArgs = {
   block?: InputMaybe<Block_Height>;
-  first?: InputMaybe<Scalars["Int"]>;
+  first?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Token_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars["Int"]>;
+  skip?: InputMaybe<Scalars['Int']>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<Token_Filter>;
 };
 
 export type Token = {
-  readonly __typename?: "Token";
-  readonly id: Scalars["ID"];
-  readonly owner: Scalars["Bytes"];
-  readonly tokenURI: Scalars["String"];
+  readonly __typename?: 'Token';
+  readonly id: Scalars['ID'];
+  readonly owner: Scalars['Bytes'];
+  readonly tokenURI: Scalars['String'];
 };
 
 export type Token_Filter = {
   /** Filter for the block changed event. */
   readonly _change_block?: InputMaybe<BlockChangedFilter>;
-  readonly id?: InputMaybe<Scalars["ID"]>;
-  readonly id_gt?: InputMaybe<Scalars["ID"]>;
-  readonly id_gte?: InputMaybe<Scalars["ID"]>;
-  readonly id_in?: InputMaybe<ReadonlyArray<Scalars["ID"]>>;
-  readonly id_lt?: InputMaybe<Scalars["ID"]>;
-  readonly id_lte?: InputMaybe<Scalars["ID"]>;
-  readonly id_not?: InputMaybe<Scalars["ID"]>;
-  readonly id_not_in?: InputMaybe<ReadonlyArray<Scalars["ID"]>>;
-  readonly owner?: InputMaybe<Scalars["Bytes"]>;
-  readonly owner_contains?: InputMaybe<Scalars["Bytes"]>;
-  readonly owner_in?: InputMaybe<ReadonlyArray<Scalars["Bytes"]>>;
-  readonly owner_not?: InputMaybe<Scalars["Bytes"]>;
-  readonly owner_not_contains?: InputMaybe<Scalars["Bytes"]>;
-  readonly owner_not_in?: InputMaybe<ReadonlyArray<Scalars["Bytes"]>>;
-  readonly tokenURI?: InputMaybe<Scalars["String"]>;
-  readonly tokenURI_contains?: InputMaybe<Scalars["String"]>;
-  readonly tokenURI_contains_nocase?: InputMaybe<Scalars["String"]>;
-  readonly tokenURI_ends_with?: InputMaybe<Scalars["String"]>;
-  readonly tokenURI_ends_with_nocase?: InputMaybe<Scalars["String"]>;
-  readonly tokenURI_gt?: InputMaybe<Scalars["String"]>;
-  readonly tokenURI_gte?: InputMaybe<Scalars["String"]>;
-  readonly tokenURI_in?: InputMaybe<ReadonlyArray<Scalars["String"]>>;
-  readonly tokenURI_lt?: InputMaybe<Scalars["String"]>;
-  readonly tokenURI_lte?: InputMaybe<Scalars["String"]>;
-  readonly tokenURI_not?: InputMaybe<Scalars["String"]>;
-  readonly tokenURI_not_contains?: InputMaybe<Scalars["String"]>;
-  readonly tokenURI_not_contains_nocase?: InputMaybe<Scalars["String"]>;
-  readonly tokenURI_not_ends_with?: InputMaybe<Scalars["String"]>;
-  readonly tokenURI_not_ends_with_nocase?: InputMaybe<Scalars["String"]>;
-  readonly tokenURI_not_in?: InputMaybe<ReadonlyArray<Scalars["String"]>>;
-  readonly tokenURI_not_starts_with?: InputMaybe<Scalars["String"]>;
-  readonly tokenURI_not_starts_with_nocase?: InputMaybe<Scalars["String"]>;
-  readonly tokenURI_starts_with?: InputMaybe<Scalars["String"]>;
-  readonly tokenURI_starts_with_nocase?: InputMaybe<Scalars["String"]>;
+  readonly id?: InputMaybe<Scalars['ID']>;
+  readonly id_gt?: InputMaybe<Scalars['ID']>;
+  readonly id_gte?: InputMaybe<Scalars['ID']>;
+  readonly id_in?: InputMaybe<ReadonlyArray<Scalars['ID']>>;
+  readonly id_lt?: InputMaybe<Scalars['ID']>;
+  readonly id_lte?: InputMaybe<Scalars['ID']>;
+  readonly id_not?: InputMaybe<Scalars['ID']>;
+  readonly id_not_in?: InputMaybe<ReadonlyArray<Scalars['ID']>>;
+  readonly owner?: InputMaybe<Scalars['Bytes']>;
+  readonly owner_contains?: InputMaybe<Scalars['Bytes']>;
+  readonly owner_in?: InputMaybe<ReadonlyArray<Scalars['Bytes']>>;
+  readonly owner_not?: InputMaybe<Scalars['Bytes']>;
+  readonly owner_not_contains?: InputMaybe<Scalars['Bytes']>;
+  readonly owner_not_in?: InputMaybe<ReadonlyArray<Scalars['Bytes']>>;
+  readonly tokenURI?: InputMaybe<Scalars['String']>;
+  readonly tokenURI_contains?: InputMaybe<Scalars['String']>;
+  readonly tokenURI_contains_nocase?: InputMaybe<Scalars['String']>;
+  readonly tokenURI_ends_with?: InputMaybe<Scalars['String']>;
+  readonly tokenURI_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  readonly tokenURI_gt?: InputMaybe<Scalars['String']>;
+  readonly tokenURI_gte?: InputMaybe<Scalars['String']>;
+  readonly tokenURI_in?: InputMaybe<ReadonlyArray<Scalars['String']>>;
+  readonly tokenURI_lt?: InputMaybe<Scalars['String']>;
+  readonly tokenURI_lte?: InputMaybe<Scalars['String']>;
+  readonly tokenURI_not?: InputMaybe<Scalars['String']>;
+  readonly tokenURI_not_contains?: InputMaybe<Scalars['String']>;
+  readonly tokenURI_not_contains_nocase?: InputMaybe<Scalars['String']>;
+  readonly tokenURI_not_ends_with?: InputMaybe<Scalars['String']>;
+  readonly tokenURI_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  readonly tokenURI_not_in?: InputMaybe<ReadonlyArray<Scalars['String']>>;
+  readonly tokenURI_not_starts_with?: InputMaybe<Scalars['String']>;
+  readonly tokenURI_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  readonly tokenURI_starts_with?: InputMaybe<Scalars['String']>;
+  readonly tokenURI_starts_with_nocase?: InputMaybe<Scalars['String']>;
 };
 
 export enum Token_OrderBy {
-  Id = "id",
-  Owner = "owner",
-  TokenUri = "tokenURI",
+  Id = 'id',
+  Owner = 'owner',
+  TokenUri = 'tokenURI'
 }
 
 export type _Block_ = {
-  readonly __typename?: "_Block_";
+  readonly __typename?: '_Block_';
   /** The hash of the block */
-  readonly hash?: Maybe<Scalars["Bytes"]>;
+  readonly hash?: Maybe<Scalars['Bytes']>;
   /** The block number */
-  readonly number: Scalars["Int"];
+  readonly number: Scalars['Int'];
 };
 
 /** The type for the top-level _meta field */
 export type _Meta_ = {
-  readonly __typename?: "_Meta_";
+  readonly __typename?: '_Meta_';
   /**
    * Information about a specific subgraph block. The hash of the block
    * will be null if the _meta field has a block constraint that asks for
@@ -172,45 +169,35 @@ export type _Meta_ = {
    */
   readonly block: _Block_;
   /** The deployment ID */
-  readonly deployment: Scalars["String"];
+  readonly deployment: Scalars['String'];
   /** If `true`, the subgraph encountered indexing errors at some past block */
-  readonly hasIndexingErrors: Scalars["Boolean"];
+  readonly hasIndexingErrors: Scalars['Boolean'];
 };
 
 export enum _SubgraphErrorPolicy_ {
   /** Data will be returned even if the subgraph has indexing errors */
-  Allow = "allow",
+  Allow = 'allow',
   /** If the subgraph has indexing errors, data will be omitted. The default. */
-  Deny = "deny",
+  Deny = 'deny'
 }
 
 export type InventoryQueryVariables = Exact<{
-  owner: Scalars["Bytes"];
+  owner: Scalars['Bytes'];
 }>;
 
-export type InventoryQuery = {
-  readonly __typename?: "Query";
-  readonly tokens: ReadonlyArray<{
-    readonly __typename?: "Token";
-    readonly id: string;
-    readonly tokenURI: string;
-  }>;
-};
+
+export type InventoryQuery = { readonly __typename?: 'Query', readonly tokens: ReadonlyArray<{ readonly __typename?: 'Token', readonly id: string, readonly tokenURI: string }> };
+
 
 export const InventoryDocument = gql`
-  query Inventory($owner: Bytes!) {
-    tokens(where: { owner: $owner }, first: 100) {
-      id
-      tokenURI
-    }
+    query Inventory($owner: Bytes!) {
+  tokens(where: {owner: $owner}, first: 100) {
+    id
+    tokenURI
   }
-`;
-
-export function useInventoryQuery(
-  options: Omit<Urql.UseQueryArgs<InventoryQueryVariables>, "query"> = {}
-) {
-  return Urql.useQuery<InventoryQuery>({
-    query: InventoryDocument,
-    ...options,
-  });
 }
+    `;
+
+export function useInventoryQuery(options: Omit<Urql.UseQueryArgs<InventoryQueryVariables>, 'query'> = {}) {
+  return Urql.useQuery<InventoryQuery>({ query: InventoryDocument, ...options });
+};

--- a/packages/app/codegen/subgraph.ts
+++ b/packages/app/codegen/subgraph.ts
@@ -1,11 +1,17 @@
-import { gql } from 'urql';
-import * as Urql from 'urql';
+import { gql } from "urql";
+import * as Urql from "urql";
 
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
-export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type Exact<T extends { [key: string]: unknown }> = {
+  [K in keyof T]: T[K];
+};
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]?: Maybe<T[SubKey]>;
+};
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]: Maybe<T[SubKey]>;
+};
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
@@ -14,152 +20,149 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   BigDecimal: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   BigInt: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Bytes: any;
 };
 
 export type BlockChangedFilter = {
-  readonly number_gte: Scalars['Int'];
+  readonly number_gte: Scalars["Int"];
 };
 
 export type Block_Height = {
-  readonly hash?: InputMaybe<Scalars['Bytes']>;
-  readonly number?: InputMaybe<Scalars['Int']>;
-  readonly number_gte?: InputMaybe<Scalars['Int']>;
+  readonly hash?: InputMaybe<Scalars["Bytes"]>;
+  readonly number?: InputMaybe<Scalars["Int"]>;
+  readonly number_gte?: InputMaybe<Scalars["Int"]>;
 };
 
 /** Defines the order direction, either ascending or descending */
 export enum OrderDirection {
-  Asc = 'asc',
-  Desc = 'desc'
+  Asc = "asc",
+  Desc = "desc",
 }
 
 export type Query = {
-  readonly __typename?: 'Query';
+  readonly __typename?: "Query";
   /** Access to subgraph metadata */
   readonly _meta?: Maybe<_Meta_>;
   readonly token?: Maybe<Token>;
   readonly tokens: ReadonlyArray<Token>;
 };
-
 
 export type Query_MetaArgs = {
   block?: InputMaybe<Block_Height>;
 };
 
-
 export type QueryTokenArgs = {
   block?: InputMaybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type QueryTokensArgs = {
   block?: InputMaybe<Block_Height>;
-  first?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars["Int"]>;
   orderBy?: InputMaybe<Token_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<Token_Filter>;
 };
 
 export type Subscription = {
-  readonly __typename?: 'Subscription';
+  readonly __typename?: "Subscription";
   /** Access to subgraph metadata */
   readonly _meta?: Maybe<_Meta_>;
   readonly token?: Maybe<Token>;
   readonly tokens: ReadonlyArray<Token>;
 };
 
-
 export type Subscription_MetaArgs = {
   block?: InputMaybe<Block_Height>;
 };
 
-
 export type SubscriptionTokenArgs = {
   block?: InputMaybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type SubscriptionTokensArgs = {
   block?: InputMaybe<Block_Height>;
-  first?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars["Int"]>;
   orderBy?: InputMaybe<Token_OrderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
-  skip?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: InputMaybe<Token_Filter>;
 };
 
 export type Token = {
-  readonly __typename?: 'Token';
-  readonly id: Scalars['ID'];
-  readonly owner: Scalars['Bytes'];
-  readonly tokenURI: Scalars['String'];
+  readonly __typename?: "Token";
+  readonly id: Scalars["ID"];
+  readonly owner: Scalars["Bytes"];
+  readonly tokenURI: Scalars["String"];
 };
 
 export type Token_Filter = {
   /** Filter for the block changed event. */
   readonly _change_block?: InputMaybe<BlockChangedFilter>;
-  readonly id?: InputMaybe<Scalars['ID']>;
-  readonly id_gt?: InputMaybe<Scalars['ID']>;
-  readonly id_gte?: InputMaybe<Scalars['ID']>;
-  readonly id_in?: InputMaybe<ReadonlyArray<Scalars['ID']>>;
-  readonly id_lt?: InputMaybe<Scalars['ID']>;
-  readonly id_lte?: InputMaybe<Scalars['ID']>;
-  readonly id_not?: InputMaybe<Scalars['ID']>;
-  readonly id_not_in?: InputMaybe<ReadonlyArray<Scalars['ID']>>;
-  readonly owner?: InputMaybe<Scalars['Bytes']>;
-  readonly owner_contains?: InputMaybe<Scalars['Bytes']>;
-  readonly owner_in?: InputMaybe<ReadonlyArray<Scalars['Bytes']>>;
-  readonly owner_not?: InputMaybe<Scalars['Bytes']>;
-  readonly owner_not_contains?: InputMaybe<Scalars['Bytes']>;
-  readonly owner_not_in?: InputMaybe<ReadonlyArray<Scalars['Bytes']>>;
-  readonly tokenURI?: InputMaybe<Scalars['String']>;
-  readonly tokenURI_contains?: InputMaybe<Scalars['String']>;
-  readonly tokenURI_contains_nocase?: InputMaybe<Scalars['String']>;
-  readonly tokenURI_ends_with?: InputMaybe<Scalars['String']>;
-  readonly tokenURI_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  readonly tokenURI_gt?: InputMaybe<Scalars['String']>;
-  readonly tokenURI_gte?: InputMaybe<Scalars['String']>;
-  readonly tokenURI_in?: InputMaybe<ReadonlyArray<Scalars['String']>>;
-  readonly tokenURI_lt?: InputMaybe<Scalars['String']>;
-  readonly tokenURI_lte?: InputMaybe<Scalars['String']>;
-  readonly tokenURI_not?: InputMaybe<Scalars['String']>;
-  readonly tokenURI_not_contains?: InputMaybe<Scalars['String']>;
-  readonly tokenURI_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  readonly tokenURI_not_ends_with?: InputMaybe<Scalars['String']>;
-  readonly tokenURI_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  readonly tokenURI_not_in?: InputMaybe<ReadonlyArray<Scalars['String']>>;
-  readonly tokenURI_not_starts_with?: InputMaybe<Scalars['String']>;
-  readonly tokenURI_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  readonly tokenURI_starts_with?: InputMaybe<Scalars['String']>;
-  readonly tokenURI_starts_with_nocase?: InputMaybe<Scalars['String']>;
+  readonly id?: InputMaybe<Scalars["ID"]>;
+  readonly id_gt?: InputMaybe<Scalars["ID"]>;
+  readonly id_gte?: InputMaybe<Scalars["ID"]>;
+  readonly id_in?: InputMaybe<ReadonlyArray<Scalars["ID"]>>;
+  readonly id_lt?: InputMaybe<Scalars["ID"]>;
+  readonly id_lte?: InputMaybe<Scalars["ID"]>;
+  readonly id_not?: InputMaybe<Scalars["ID"]>;
+  readonly id_not_in?: InputMaybe<ReadonlyArray<Scalars["ID"]>>;
+  readonly owner?: InputMaybe<Scalars["Bytes"]>;
+  readonly owner_contains?: InputMaybe<Scalars["Bytes"]>;
+  readonly owner_in?: InputMaybe<ReadonlyArray<Scalars["Bytes"]>>;
+  readonly owner_not?: InputMaybe<Scalars["Bytes"]>;
+  readonly owner_not_contains?: InputMaybe<Scalars["Bytes"]>;
+  readonly owner_not_in?: InputMaybe<ReadonlyArray<Scalars["Bytes"]>>;
+  readonly tokenURI?: InputMaybe<Scalars["String"]>;
+  readonly tokenURI_contains?: InputMaybe<Scalars["String"]>;
+  readonly tokenURI_contains_nocase?: InputMaybe<Scalars["String"]>;
+  readonly tokenURI_ends_with?: InputMaybe<Scalars["String"]>;
+  readonly tokenURI_ends_with_nocase?: InputMaybe<Scalars["String"]>;
+  readonly tokenURI_gt?: InputMaybe<Scalars["String"]>;
+  readonly tokenURI_gte?: InputMaybe<Scalars["String"]>;
+  readonly tokenURI_in?: InputMaybe<ReadonlyArray<Scalars["String"]>>;
+  readonly tokenURI_lt?: InputMaybe<Scalars["String"]>;
+  readonly tokenURI_lte?: InputMaybe<Scalars["String"]>;
+  readonly tokenURI_not?: InputMaybe<Scalars["String"]>;
+  readonly tokenURI_not_contains?: InputMaybe<Scalars["String"]>;
+  readonly tokenURI_not_contains_nocase?: InputMaybe<Scalars["String"]>;
+  readonly tokenURI_not_ends_with?: InputMaybe<Scalars["String"]>;
+  readonly tokenURI_not_ends_with_nocase?: InputMaybe<Scalars["String"]>;
+  readonly tokenURI_not_in?: InputMaybe<ReadonlyArray<Scalars["String"]>>;
+  readonly tokenURI_not_starts_with?: InputMaybe<Scalars["String"]>;
+  readonly tokenURI_not_starts_with_nocase?: InputMaybe<Scalars["String"]>;
+  readonly tokenURI_starts_with?: InputMaybe<Scalars["String"]>;
+  readonly tokenURI_starts_with_nocase?: InputMaybe<Scalars["String"]>;
 };
 
 export enum Token_OrderBy {
-  Id = 'id',
-  Owner = 'owner',
-  TokenUri = 'tokenURI'
+  Id = "id",
+  Owner = "owner",
+  TokenUri = "tokenURI",
 }
 
 export type _Block_ = {
-  readonly __typename?: '_Block_';
+  readonly __typename?: "_Block_";
   /** The hash of the block */
-  readonly hash?: Maybe<Scalars['Bytes']>;
+  readonly hash?: Maybe<Scalars["Bytes"]>;
   /** The block number */
-  readonly number: Scalars['Int'];
+  readonly number: Scalars["Int"];
 };
 
 /** The type for the top-level _meta field */
 export type _Meta_ = {
-  readonly __typename?: '_Meta_';
+  readonly __typename?: "_Meta_";
   /**
    * Information about a specific subgraph block. The hash of the block
    * will be null if the _meta field has a block constraint that asks for
@@ -169,35 +172,45 @@ export type _Meta_ = {
    */
   readonly block: _Block_;
   /** The deployment ID */
-  readonly deployment: Scalars['String'];
+  readonly deployment: Scalars["String"];
   /** If `true`, the subgraph encountered indexing errors at some past block */
-  readonly hasIndexingErrors: Scalars['Boolean'];
+  readonly hasIndexingErrors: Scalars["Boolean"];
 };
 
 export enum _SubgraphErrorPolicy_ {
   /** Data will be returned even if the subgraph has indexing errors */
-  Allow = 'allow',
+  Allow = "allow",
   /** If the subgraph has indexing errors, data will be omitted. The default. */
-  Deny = 'deny'
+  Deny = "deny",
 }
 
 export type InventoryQueryVariables = Exact<{
-  owner: Scalars['Bytes'];
+  owner: Scalars["Bytes"];
 }>;
 
-
-export type InventoryQuery = { readonly __typename?: 'Query', readonly tokens: ReadonlyArray<{ readonly __typename?: 'Token', readonly id: string, readonly tokenURI: string }> };
-
+export type InventoryQuery = {
+  readonly __typename?: "Query";
+  readonly tokens: ReadonlyArray<{
+    readonly __typename?: "Token";
+    readonly id: string;
+    readonly tokenURI: string;
+  }>;
+};
 
 export const InventoryDocument = gql`
-    query Inventory($owner: Bytes!) {
-  tokens(where: {owner: $owner}, first: 100) {
-    id
-    tokenURI
+  query Inventory($owner: Bytes!) {
+    tokens(where: { owner: $owner }, first: 100) {
+      id
+      tokenURI
+    }
   }
-}
-    `;
+`;
 
-export function useInventoryQuery(options: Omit<Urql.UseQueryArgs<InventoryQueryVariables>, 'query'> = {}) {
-  return Urql.useQuery<InventoryQuery>({ query: InventoryDocument, ...options });
-};
+export function useInventoryQuery(
+  options: Omit<Urql.UseQueryArgs<InventoryQueryVariables>, "query"> = {}
+) {
+  return Urql.useQuery<InventoryQuery>({
+    query: InventoryDocument,
+    ...options,
+  });
+}

--- a/packages/app/src/EthereumProviders.tsx
+++ b/packages/app/src/EthereumProviders.tsx
@@ -5,12 +5,12 @@ import { chain, configureChains, createClient, WagmiConfig } from "wagmi";
 import { alchemyProvider } from "wagmi/providers/alchemy";
 import { publicProvider } from "wagmi/providers/public";
 
-export const targetChainId = parseInt(process.env.CHAIN_ID!) || 5;
+export const targetChainId = parseInt(process.env.CHAIN_ID || "0") || 5;
 
 export const { chains, provider, webSocketProvider } = configureChains(
   [chain.mainnet, chain.goerli],
   [
-    alchemyProvider({ alchemyId: process.env.NEXT_PUBLIC_ALCHEMY_API_KEY! }),
+    alchemyProvider({ alchemyId: process.env.NEXT_PUBLIC_ALCHEMY_API_KEY }),
     publicProvider(),
   ]
 );

--- a/packages/app/src/Inventory.tsx
+++ b/packages/app/src/Inventory.tsx
@@ -1,5 +1,5 @@
 import { gql } from "urql";
-import { useAccount, useNetwork } from "wagmi";
+import { useAccount } from "wagmi";
 
 import { useInventoryQuery } from "../codegen/subgraph";
 import { exampleNFTContract } from "./contracts";
@@ -18,7 +18,7 @@ gql`
 export const Inventory = () => {
   const { address } = useAccount();
 
-  const [query, refetchQuery] = useInventoryQuery({
+  const [query] = useInventoryQuery({
     pause: !address,
     variables: {
       owner: address?.toLowerCase(),

--- a/packages/app/src/MintButton.tsx
+++ b/packages/app/src/MintButton.tsx
@@ -63,7 +63,7 @@ export const MintButton = () => {
         mint(1, (message) => {
           toast.update(toastId, { render: message });
         }).then(
-          ({ receipt }) => {
+          () => {
             // TODO: show etherscan link?
             toast.update(toastId, {
               isLoading: false,

--- a/packages/app/src/extractContractError.ts
+++ b/packages/app/src/extractContractError.ts
@@ -6,6 +6,7 @@ const contractInterface = ExampleNFT__factory.createInterface();
 //   console.log(contractInterface.getSighash(errorFragment), errorFragment.name);
 // }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const extractContractError = (error: any): string => {
   console.dir(error);
 
@@ -13,9 +14,7 @@ export const extractContractError = (error: any): string => {
   const errorData = error.error?.data?.originalError?.data;
   if (typeof errorData === "string") {
     console.log("found error data in original error, write call?", errorData);
-    for (const [error, errorFragment] of Object.entries(
-      contractInterface.errors
-    )) {
+    for (const [, errorFragment] of Object.entries(contractInterface.errors)) {
       if (errorData.startsWith(contractInterface.getSighash(errorFragment))) {
         // const args = contractInterface.decodeErrorResult(errorFragment, errorData)
         return errorFragment.name;
@@ -29,7 +28,7 @@ export const extractContractError = (error: any): string => {
     const errorData = response.error.data;
     console.log("found error data in error response, read call?", errorData);
     if (typeof errorData === "string") {
-      for (const [error, errorFragment] of Object.entries(
+      for (const [, errorFragment] of Object.entries(
         contractInterface.errors
       )) {
         if (errorData.startsWith(contractInterface.getSighash(errorFragment))) {

--- a/packages/app/src/useENS.ts
+++ b/packages/app/src/useENS.ts
@@ -5,11 +5,12 @@ import { persist } from "zustand/middleware";
 import { cachedFetch } from "./cachedFetch";
 
 type State = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   resolvedAddresses: Partial<Record<string, any>>;
 };
 
 export const useStore = createStore<State>(
-  persist((set) => ({ resolvedAddresses: {} }), { name: "resolved-ens" })
+  persist(() => ({ resolvedAddresses: {} }), { name: "resolved-ens" })
 );
 
 export const useENS = (address: string) => {

--- a/packages/app/src/useENS.ts
+++ b/packages/app/src/useENS.ts
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import createStore from "zustand";
 import { persist } from "zustand/middleware";
 

--- a/packages/app/src/usePromiseFn.ts
+++ b/packages/app/src/usePromiseFn.ts
@@ -12,6 +12,7 @@ type PromiseState<TValue> =
   | { type: "fulfilled"; value: TValue }
   | { type: "rejected"; error: unknown };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AsyncFunction = (...args: any[]) => PromiseLike<any>;
 
 export const usePromiseFn = <TFunc extends AsyncFunction>(
@@ -64,7 +65,7 @@ export const usePromiseFn = <TFunc extends AsyncFunction>(
       return promise;
       // eslint-disable-next-line react-hooks/exhaustive-deps
     },
-    [...deps, currentValue]
+    [...deps, currentValue, promiseFn]
   );
 
   return [state, mutate];

--- a/packages/app/src/usePromiseFn.ts
+++ b/packages/app/src/usePromiseFn.ts
@@ -63,8 +63,8 @@ export const usePromiseFn = <TFunc extends AsyncFunction>(
           setState({ type: "rejected", error })
       );
       return promise;
-      // eslint-disable-next-line react-hooks/exhaustive-deps
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [...deps, currentValue, promiseFn]
   );
 

--- a/packages/app/src/usePromiseFn.ts
+++ b/packages/app/src/usePromiseFn.ts
@@ -65,7 +65,7 @@ export const usePromiseFn = <TFunc extends AsyncFunction>(
       return promise;
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [...deps, currentValue, promiseFn]
+    [...deps, currentValue]
   );
 
   return [state, mutate];


### PR DESCRIPTION
Addresses https://github.com/holic/web3-scaffold/issues/37.

There are still some uses of `any` type that I left as-is with ignore statements, maybe we can revisit those later. For some of the types (BigInt, BigDecimal, etc) there aren't native TypeScript equivalents, but maybe third-party packages we can look into at some point.