### PR TITLE
fix: add placeholder script folder & update foundry.toml

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -14,3 +14,4 @@ verbosity = 2
 bytecode_hash = 'none'
 solc_version = '0.8.13'
 extra_output_files = ['abi']
+script = 'packages/contracts/script'


### PR DESCRIPTION
Adds a placeholder `script` folder and fixes [reported issue](https://discord.com/channels/890053994926460939/994105254276759582/997917237295980544) with compiling from a script.