### PR TITLE
Update EthereumProviders to allow for other testnets

### DIFF
--- a/packages/app/.env
+++ b/packages/app/.env
@@ -11,8 +11,8 @@
 
 # Find your chainID here: https://chainlist.org/
 # By default we use 5, or the Goerli network
-CHAIN_ID=5
 NEXT_PUBLIC_CHAIN_ID=5
 
 # Provide your ALCHEMY API Key here
 NEXT_PUBLIC_ALCHEMY_API_KEY=
+

--- a/packages/app/.env
+++ b/packages/app/.env
@@ -12,6 +12,7 @@
 # Find your chainID here: https://chainlist.org/
 # By default we use 5, or the Goerli network
 CHAIN_ID=5
+NEXT_PUBLIC_CHAIN_ID=5
 
 # Provide your ALCHEMY API Key here
 NEXT_PUBLIC_ALCHEMY_API_KEY=

--- a/packages/app/src/EthereumProviders.tsx
+++ b/packages/app/src/EthereumProviders.tsx
@@ -1,28 +1,25 @@
 import "@rainbow-me/rainbowkit/styles.css";
 
 import { getDefaultWallets, RainbowKitProvider } from "@rainbow-me/rainbowkit";
-import { chain, configureChains, createClient, WagmiConfig } from "wagmi";
+import {
+  chain,
+  configureChains,
+  createClient,
+  defaultChains,
+  WagmiConfig,
+} from "wagmi";
 import { alchemyProvider } from "wagmi/providers/alchemy";
 import { publicProvider } from "wagmi/providers/public";
 
+// Will default to goerli if nothing set in the ENV
 export const targetChainId =
   parseInt(process.env.NEXT_PUBLIC_CHAIN_ID || "0") || 5;
-const targetChains = [chain.mainnet];
-switch (targetChainId) {
-  case 3:
-    targetChains.push(chain.ropsten);
-    break;
-  case 4:
-    targetChains.push(chain.rinkeby);
-    break;
-  case 42:
-    targetChains.push(chain.kovan);
-    break;
-  case 5:
-  default:
-    targetChains.push(chain.goerli);
-    break;
-}
+
+// filter down to just mainnet + optional target testnet chain so that rainbowkit can tell
+// the user to switch network if they're on an alternative one
+const targetChains = defaultChains.filter(
+  (chain) => chain.id === 1 || chain.id === targetChainId
+);
 
 export const { chains, provider, webSocketProvider } = configureChains(
   targetChains,

--- a/packages/app/src/EthereumProviders.tsx
+++ b/packages/app/src/EthereumProviders.tsx
@@ -5,10 +5,27 @@ import { chain, configureChains, createClient, WagmiConfig } from "wagmi";
 import { alchemyProvider } from "wagmi/providers/alchemy";
 import { publicProvider } from "wagmi/providers/public";
 
-export const targetChainId = parseInt(process.env.CHAIN_ID || "0") || 5;
+export const targetChainId =
+  parseInt(process.env.NEXT_PUBLIC_CHAIN_ID || "0") || 5;
+const targetChains = [chain.mainnet];
+switch (targetChainId) {
+  case 3:
+    targetChains.push(chain.ropsten);
+    break;
+  case 4:
+    targetChains.push(chain.rinkeby);
+    break;
+  case 42:
+    targetChains.push(chain.kovan);
+    break;
+  case 5:
+  default:
+    targetChains.push(chain.goerli);
+    break;
+}
 
 export const { chains, provider, webSocketProvider } = configureChains(
-  [chain.mainnet, chain.goerli],
+  targetChains,
   [
     alchemyProvider({ alchemyId: process.env.NEXT_PUBLIC_ALCHEMY_API_KEY }),
     publicProvider(),


### PR DESCRIPTION
Y'all can decide if you want to include this or not, but I found I still needed to be able to deploy to Rinekby to properly test stuff.. Goerli just isn't fully supported by OS or other platforms yet.